### PR TITLE
fix bug in some jei handlers showing wrong energy consumption

### DIFF
--- a/src/main/java/com/leafia/jei/JEIArcWelder.java
+++ b/src/main/java/com/leafia/jei/JEIArcWelder.java
@@ -97,9 +97,9 @@ public class JEIArcWelder implements IRecipeCategory<Recipe> {
 					I18nUtil.resolveKey(
 							"desc.leafia._jei.energy_"+(shift ? "t" : "s"),
 							SIPfx.format("%,"+LeafiaUtil.getFormatDecimal(
-									shift ? this.consumption : this.consumption/20f,
+									shift ? this.consumption : this.consumption*20f,
 									0,3
-							),shift ? this.consumption : this.consumption/20f,false)+"HE"
+							),shift ? this.consumption : this.consumption*20f,false)+"HE"
 					);
 			int height = 9;
 			font.drawString(duration,recipeWidth-font.getStringWidth(duration),recipeHeight-height*2,0x404040);

--- a/src/main/java/com/leafia/jei/JEISoldering.java
+++ b/src/main/java/com/leafia/jei/JEISoldering.java
@@ -115,9 +115,9 @@ public class JEISoldering implements IRecipeCategory<Recipe> {
 					I18nUtil.resolveKey(
 							"desc.leafia._jei.energy_"+(shift ? "t" : "s"),
 							SIPfx.format("%,"+LeafiaUtil.getFormatDecimal(
-									shift ? this.consumption : this.consumption/20f,
+									shift ? this.consumption : this.consumption*	20f,
 									0,3
-							),shift ? this.consumption : this.consumption/20f,false)+"HE"
+							),shift ? this.consumption : this.consumption*20f,false)+"HE"
 					);
 			int height = 9;
 			font.drawString(duration,recipeWidth-font.getStringWidth(duration),recipeHeight-height*2,0x404040);

--- a/src/main/java/com/leafia/jei/JEISoldering.java
+++ b/src/main/java/com/leafia/jei/JEISoldering.java
@@ -115,7 +115,7 @@ public class JEISoldering implements IRecipeCategory<Recipe> {
 					I18nUtil.resolveKey(
 							"desc.leafia._jei.energy_"+(shift ? "t" : "s"),
 							SIPfx.format("%,"+LeafiaUtil.getFormatDecimal(
-									shift ? this.consumption : this.consumption*	20f,
+									shift ? this.consumption : this.consumption*20f,
 									0,3
 							),shift ? this.consumption : this.consumption*20f,false)+"HE"
 					);


### PR DESCRIPTION
fix bug in some jei handlers where the per second view energy consumption was divided by 20 instead of multiplied by 20.
sorry if this is horrible slop this is my first time trying to make a PR

before: 
<img width="396" height="183" alt="Screenshot from 2026-05-16 12-44-23" src="https://github.com/user-attachments/assets/82bb8ee8-6062-428c-b155-f70c2c6595ff" />


after: 
<img width="423" height="194" alt="image" src="https://github.com/user-attachments/assets/0a05ccb7-adc2-42f6-874a-ef6c2b01386c" />